### PR TITLE
added a field for the interaction type

### DIFF
--- a/integration_test/pact_publish_test.dart
+++ b/integration_test/pact_publish_test.dart
@@ -21,6 +21,7 @@ void main() {
           ..state = 'pet shop with 3 pets'
           ..addRequest((req) => req
             ..description = 'should get pet list'
+            ..type = InteractionType.SYNCHRONOUS_HTTP
             ..method = Method.GET
             ..path = '/pets/'
             ..setResponse((resp) => resp

--- a/lib/src/contract_builder_api.dart
+++ b/lib/src/contract_builder_api.dart
@@ -163,6 +163,7 @@ class RequestBuilder {
     assert(path != null);
     assert(query != null);
     assert(method != null);
+    assert(type != null);
     assert(_response != null);
     assert(body != null);
     assert(headers != null);

--- a/lib/src/contract_builder_api.dart
+++ b/lib/src/contract_builder_api.dart
@@ -48,6 +48,7 @@ class PactRepository {
     return Interaction()
       ..description = requestBuilder.description
       ..providerStates = [ProviderState()..name = state]
+      ..type = requestBuilder.type.value
       ..request = (_toRequest(requestBuilder))
       ..response = (_toResponse(requestBuilder.response));
   }
@@ -111,6 +112,13 @@ class PactBuilder {
 
 enum Method { GET, POST, DELETE, PUT }
 
+class InteractionType {
+  final String value;
+  InteractionType._(this.value);
+
+  static InteractionType SYNCHRONOUS_HTTP = InteractionType._('Synchronous/HTTP');
+}
+
 class StateBuilder {
   String state;
 
@@ -135,6 +143,7 @@ class RequestBuilder {
   String path;
   String description = '';
   Method method = Method.GET;
+  InteractionType type = InteractionType.SYNCHRONOUS_HTTP;
   ResponseBuilder _response;
 
   Map<String, String> query = {};

--- a/lib/src/pact_contract_dto.dart
+++ b/lib/src/pact_contract_dto.dart
@@ -39,6 +39,7 @@ class Metadata {
 
 @JsonSerializable()
 class Interaction {
+  String type;
   String description;
   Request request;
   Response response;

--- a/lib/src/pact_contract_dto.g.dart
+++ b/lib/src/pact_contract_dto.g.dart
@@ -66,6 +66,7 @@ Map<String, dynamic> _$MetadataToJson(Metadata instance) {
 
 Interaction _$InteractionFromJson(Map<String, dynamic> json) {
   return Interaction()
+    ..type = json['type'] as String
     ..description = json['description'] as String
     ..request = json['request'] == null
         ? null
@@ -89,6 +90,7 @@ Map<String, dynamic> _$InteractionToJson(Interaction instance) {
     }
   }
 
+  writeNotNull('type', instance.type);
   writeNotNull('description', instance.description);
   writeNotNull('request', instance.request);
   writeNotNull('response', instance.response);

--- a/test/pact_dto_test.dart
+++ b/test/pact_dto_test.dart
@@ -16,6 +16,7 @@ void main() {
           Interaction()
             ..description = 'my description'
             ..providerStates = [ProviderState()..name = 'my state']
+            ..type = 'Synchronous/HTTP'
             ..request = (Request()
               ..method = 'GET'
               ..path = 'my/path'
@@ -37,7 +38,7 @@ void main() {
       var asString = jsonEncode(asJson);
       //prints(asJson);
       const expected =
-      '''{"provider":{"name":"my Provider"},"consumer":{"name":"my consumer"},"interactions":[{"description":"my description","request":{"method":"GET","path":"my/path","query":{"name":"john"},"headers":{"accept":"application/json"},"body":[{"my-key":"my-value"},"plain string"]},"response":{"status":200,"headers":{"content-type":"text/plain"},"body":null},"providerStates":[{"name":"my state","params":{}}]}],"metadata":{"pactSpecification":{"version":"4.0"},"pact-dart":{"version":"0.0.1"}}}''';
+      '''{"provider":{"name":"my Provider"},"consumer":{"name":"my consumer"},"interactions":[{"type":"Synchronous/HTTP","description":"my description","request":{"method":"GET","path":"my/path","query":{"name":"john"},"headers":{"accept":"application/json"},"body":[{"my-key":"my-value"},"plain string"]},"response":{"status":200,"headers":{"content-type":"text/plain"},"body":null},"providerStates":[{"name":"my state","params":{}}]}],"metadata":{"pactSpecification":{"version":"4.0"},"pact-dart":{"version":"0.0.1"}}}''';
       expect(asString, expected);
     });
   });


### PR DESCRIPTION
The PactSpec has a field for the interaction type.
https://github.com/pact-foundation/pact-specification/tree/version-4#interactions

The broker accepts PACTs without it, but the JVM-Implementation will fail if the field is missing:
https://github.com/pact-foundation/pact-jvm/blob/d5630e6093abcef20ecec727f6b1c0b79bf5cf2d/core/model/src/main/kotlin/au/com/dius/pact/core/model/V4Pact.kt#L324