### PR TITLE
Serialise body according to v4 spec

### DIFF
--- a/integration_test/pact_publish_test.dart
+++ b/integration_test/pact_publish_test.dart
@@ -21,6 +21,7 @@ void main() {
           ..state = 'pet shop with 3 pets'
           ..addRequest((req) => req
             ..description = 'should get pet list'
+            ..type = InteractionType.SYNCHRONOUS_HTTP
             ..method = Method.GET
             ..path = '/pets/'
             ..setResponse((resp) => resp

--- a/lib/src/contract_builder_api.dart
+++ b/lib/src/contract_builder_api.dart
@@ -163,6 +163,7 @@ class RequestBuilder {
     assert(path != null);
     assert(query != null);
     assert(method != null);
+    assert(type != null);
     assert(_response != null);
     assert(body != null);
     assert(headers != null);

--- a/lib/src/contract_builder_api.dart
+++ b/lib/src/contract_builder_api.dart
@@ -48,6 +48,7 @@ class PactRepository {
     return Interaction()
       ..description = requestBuilder.description
       ..providerStates = [ProviderState()..name = state]
+      ..type = requestBuilder.type.value
       ..request = (_toRequest(requestBuilder))
       ..response = (_toResponse(requestBuilder.response));
   }
@@ -111,6 +112,13 @@ class PactBuilder {
 
 enum Method { GET, POST, DELETE, PUT }
 
+class InteractionType {
+  final String value;
+  InteractionType._(this.value);
+
+  static InteractionType SYNCHRONOUS_HTTP = InteractionType._('Synchronous/HTTP');
+}
+
 class StateBuilder {
   String state;
 
@@ -135,6 +143,7 @@ class RequestBuilder {
   String path;
   String description = '';
   Method method = Method.GET;
+  InteractionType type = InteractionType.SYNCHRONOUS_HTTP;
   ResponseBuilder _response;
 
   Map<String, String> query = {};

--- a/lib/src/contract_builder_api.dart
+++ b/lib/src/contract_builder_api.dart
@@ -58,7 +58,7 @@ class PactRepository {
       ..method = _toMethod(requestBuilder.method)
       ..path = requestBuilder.path
       ..query = requestBuilder.query
-      ..body = requestBuilder.body
+      ..body = (_toBody(requestBuilder.body))
       ..headers = requestBuilder.headers;
   }
 
@@ -66,13 +66,22 @@ class PactRepository {
     return Response()
       ..headers = response.headers
       ..status = response.status.code
-      ..body = response.body;
+      ..body = (_toBody(response.body));
+  }
+
+  RequestResponseBody _toBody(Body body) {
+    return RequestResponseBody()
+        ..content = body.content
+        ..contentType = body.contentType
+        ..encoded = body.encoded;
   }
 
   String _toMethod(Method method) {
     const prefix = 'Method.';
     return method.toString().substring(prefix.length);
   }
+
+
 }
 
 /// DSL for building pact contracts.
@@ -190,21 +199,18 @@ class ResponseBuilder {
 }
 
 /// Models a request/response body.
-class Body extends Union3<Json, String, Unit> implements CustomJson {
-  Body.json(Json json) : super.t1(json);
+class Body {
+  final String contentType;
+  final String encoded = 'false';
+  final dynamic content;
 
-  Body.string(String str) : super.t2(str);
+  Body.json(Json json):
+    contentType = 'application/json',
+    content = json.toJson();
 
-  Body.none() : super.t3(unit);
+  Body.string(this.content, this.contentType);
 
-  @override
-  dynamic toJson() {
-    return fold(
-      (js) => js.toJson(),
-      (str) => str,
-      (unit) => unit.toJson(),
-    );
-  }
+  Body.none(): contentType = null, content = null;
 }
 
 /// Models a Json object.

--- a/lib/src/pact_contract_dto.dart
+++ b/lib/src/pact_contract_dto.dart
@@ -39,6 +39,7 @@ class Metadata {
 
 @JsonSerializable()
 class Interaction {
+  String type;
   String description;
   Request request;
   Response response;

--- a/lib/src/pact_contract_dto.dart
+++ b/lib/src/pact_contract_dto.dart
@@ -74,13 +74,26 @@ class Response {
 
   Map<String, String> headers = {};
 
-  @JsonKey(fromJson: _fromJsonToBody)
-  Body body;
+  RequestResponseBody body;
 
   factory Response.fromJson(Map<String, dynamic> json) =>
       _$ResponseFromJson(json);
 
   Map<String, dynamic> toJson() => _$ResponseToJson(this);
+}
+
+@JsonSerializable()
+class RequestResponseBody {
+  String contentType;
+  String encoded;
+  dynamic content;
+
+  RequestResponseBody();
+
+  factory RequestResponseBody.fromJson(Map<String, dynamic> json) =>
+      _$RequestResponseBodyFromJson(json);
+
+  Map<String, dynamic> toJson() => _$RequestResponseBodyToJson(this);
 }
 
 @JsonSerializable()
@@ -91,9 +104,7 @@ class Request {
   String path;
   Map<String, String> query = {};
   Map<String, String> headers = {};
-
-  @JsonKey(fromJson: _fromJsonToBody)
-  Body body;
+  RequestResponseBody body;
 
   factory Request.fromJson(Map<String, dynamic> json) =>
       _$RequestFromJson(json);
@@ -123,23 +134,4 @@ class Consumer {
       _$ConsumerFromJson(json);
 
   Map<String, dynamic> toJson() => _$ConsumerToJson(this);
-}
-
-Body _fromJsonToBody(dynamic body) {
-  if (body == null) {
-    return Body.none();
-  }
-
-  if (body is String) {
-    return Body.string(body);
-  }
-
-  if (body is Map<String, dynamic>) {
-    return Body.json(Json.object(body));
-  }
-
-  if (body is Iterable<dynamic>) {
-    return Body.json(Json.array(body));
-  }
-  throw AssertionError('Unknown body type ${body.runtimeType}');
 }

--- a/lib/src/pact_contract_dto.g.dart
+++ b/lib/src/pact_contract_dto.g.dart
@@ -124,7 +124,9 @@ Response _$ResponseFromJson(Map<String, dynamic> json) {
     ..headers = (json['headers'] as Map<String, dynamic>)?.map(
       (k, e) => MapEntry(k, e as String),
     )
-    ..body = _fromJsonToBody(json['body']);
+    ..body = json['body'] == null
+        ? null
+        : RequestResponseBody.fromJson(json['body'] as Map<String, dynamic>);
 }
 
 Map<String, dynamic> _$ResponseToJson(Response instance) {
@@ -142,6 +144,28 @@ Map<String, dynamic> _$ResponseToJson(Response instance) {
   return val;
 }
 
+RequestResponseBody _$RequestResponseBodyFromJson(Map<String, dynamic> json) {
+  return RequestResponseBody()
+    ..contentType = json['contentType'] as String
+    ..encoded = json['encoded'] as String
+    ..content = json['content'];
+}
+
+Map<String, dynamic> _$RequestResponseBodyToJson(RequestResponseBody instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('contentType', instance.contentType);
+  writeNotNull('encoded', instance.encoded);
+  writeNotNull('content', instance.content);
+  return val;
+}
+
 Request _$RequestFromJson(Map<String, dynamic> json) {
   return Request()
     ..method = json['method'] as String
@@ -152,7 +176,9 @@ Request _$RequestFromJson(Map<String, dynamic> json) {
     ..headers = (json['headers'] as Map<String, dynamic>)?.map(
       (k, e) => MapEntry(k, e as String),
     )
-    ..body = _fromJsonToBody(json['body']);
+    ..body = json['body'] == null
+        ? null
+        : RequestResponseBody.fromJson(json['body'] as Map<String, dynamic>);
 }
 
 Map<String, dynamic> _$RequestToJson(Request instance) {

--- a/lib/src/pact_contract_dto.g.dart
+++ b/lib/src/pact_contract_dto.g.dart
@@ -66,6 +66,7 @@ Map<String, dynamic> _$MetadataToJson(Metadata instance) {
 
 Interaction _$InteractionFromJson(Map<String, dynamic> json) {
   return Interaction()
+    ..type = json['type'] as String
     ..description = json['description'] as String
     ..request = json['request'] == null
         ? null
@@ -89,6 +90,7 @@ Map<String, dynamic> _$InteractionToJson(Interaction instance) {
     }
   }
 
+  writeNotNull('type', instance.type);
   writeNotNull('description', instance.description);
   writeNotNull('request', instance.request);
   writeNotNull('response', instance.response);

--- a/test/pact_dto_test.dart
+++ b/test/pact_dto_test.dart
@@ -16,6 +16,7 @@ void main() {
           Interaction()
             ..description = 'my description'
             ..providerStates = [ProviderState()..name = 'my state']
+            ..type = 'Synchronous/HTTP'
             ..request = (Request()
               ..method = 'GET'
               ..path = 'my/path'
@@ -37,7 +38,7 @@ void main() {
       var asString = jsonEncode(asJson);
       //prints(asJson);
       const expected =
-      '''{"provider":{"name":"my Provider"},"consumer":{"name":"my consumer"},"interactions":[{"description":"my description","request":{"method":"GET","path":"my/path","query":{"name":"john"},"headers":{"accept":"application/json"},"body":[{"my-key":"my-value"},"plain string"]},"response":{"status":200,"headers":{"content-type":"text/plain"},"body":null},"providerStates":[{"name":"my state","params":{}}]}],"metadata":{"pactSpecification":{"version":"4.0"},"pact-dart":{"version":"0.0.1"}}}''';
+      '''{"provider":{"name":"my Provider"},"consumer":{"name":"my consumer"},"interactions":[{"type":"Synchronous/HTTP","description":"my description","request":{"method":"GET","path":"my/path","query":{"name":"john"},"headers":{"accept":"application/json"},"body":[{"my-key":"my-value"},"plain string"]},"response":{"status":200,"headers":{"content-type":"text/plain"},"body":null},"providerStates":[{"name":"my state","params":{}}]}],"metadata":{"pactSpecification":{"version":"4.0"},"pact-dart":{"version":"0.0.1"}}}''';
       expect(asString, expected);
     });
   });

--- a/test/pact_dto_test.dart
+++ b/test/pact_dto_test.dart
@@ -22,23 +22,18 @@ void main() {
               ..path = 'my/path'
               ..query = {'name': 'john'}
               ..headers = {'accept': 'application/json'}
-              ..body = Body.json(
-                Json.array([
-                  Json.object({"my-key": "my-value"}),
-                  "plain string"
-                ]),
-              ))
+              ..body = (RequestResponseBody()..content = {"my-key": "my-value"}))
             ..response = (Response()
               ..headers = {"content-type": "text/plain"}
               ..status = 200
-              ..body = Body.none())
+              ..body = null)
         ];
 
       var asJson = contract.toJson();
       var asString = jsonEncode(asJson);
       //prints(asJson);
       const expected =
-      '''{"provider":{"name":"my Provider"},"consumer":{"name":"my consumer"},"interactions":[{"type":"Synchronous/HTTP","description":"my description","request":{"method":"GET","path":"my/path","query":{"name":"john"},"headers":{"accept":"application/json"},"body":[{"my-key":"my-value"},"plain string"]},"response":{"status":200,"headers":{"content-type":"text/plain"},"body":null},"providerStates":[{"name":"my state","params":{}}]}],"metadata":{"pactSpecification":{"version":"4.0"},"pact-dart":{"version":"0.0.1"}}}''';
+      '''{"provider":{"name":"my Provider"},"consumer":{"name":"my consumer"},"interactions":[{"type":"Synchronous/HTTP","description":"my description","request":{"method":"GET","path":"my/path","query":{"name":"john"},"headers":{"accept":"application/json"},"body":{"content":{"my-key":"my-value"}}},"response":{"status":200,"headers":{"content-type":"text/plain"}},"providerStates":[{"name":"my state","params":{}}]}],"metadata":{"pactSpecification":{"version":"4.0"},"pact-dart":{"version":"0.0.1"}}}''';
       expect(asString, expected);
     });
   });


### PR DESCRIPTION
I added a wrapper object to the body to match the v4 body spec and tested it against the PACT-JVM-Provider Tests.
They can now validate the body - before that, the body was reported as missing.

Frankly, I'm not quiet sure if this is what you intended to do, or if you had other use cases in mind. I tried to preserve the contract-builder API, but had to drop the custom-json serialisation to get this to work. So please feel free to ignore this PR and have a go at it yourself if I misunderstood your intentions here!

Fixes #4 