### PR TITLE
Bumps dart SDK to 2.12 and FFI to stable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,10 @@
 
 - Introduces pact matching in unit tests
 - Better documentation
+
+## 0.2.0
+
+- Bumps dart SDK to 2.12
+- Updates dependencies to match dart SDK 2.12
+- Enables null safety
+- Bumps pact native library to 0.1.1

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -16,6 +16,10 @@ Run `dart test`
 
 ## Integration tests
 
-Docker setup in the [docker](./docker) folder.
+Launch the pact broker container in the [compose](./docker/docker-compose.yaml) file.
 
-Then launch the integration tests with `dart test integration_test`
+Run the tests specifying the `PACT_HOST` flag in a `define` parameter. The test command doesn't respect the values
+passed as environment ([issue](https://github.com/dart-lang/sdk/issues/44562)), so we need to run each test
+individually with the `run` command.
+
+Or use the script `ls integration_test | xargs -i dart -DPACT_HOST=[broker] run integration_test/{}`.

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -7,7 +7,12 @@ The bindings work with a specific version of the rust library. There are no comp
 If all planets align is even possible to write code that runs, but gives incorrect results due to incompatible bindings.
 
 ## Pact DTO generation
-`dart pub run build_runner build --delete-conflicting-outputs`
+`dart run build_runner build --delete-conflicting-outputs`
+
+## Unit test
+Download the ffi library from github `dart run dart_pact_consumer:github_download`
+
+Run `dart test`
 
 ## Integration tests
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ final serverFactory = await MockServerFactory.create();
 The mock server requires an external library to launch, made by the team behind pact. This package uses defaults to
 load such library but it needs to be downloaded previously.
 
-To use the defaults run `dart pub run dart_pact_consumer:github_download`.
+To use the defaults run `dart run dart_pact_consumer:github_download`.
 
 ### Define each interaction
 ```dart

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:pedantic_mono/analysis_options.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/bin/github_download.dart
+++ b/bin/github_download.dart
@@ -25,16 +25,16 @@ Future<String> downloadFromGithub() async {
   return _finalPath;
 }
 
-void _unzip() async {
+Future<void> _unzip() async {
   print('Decompressing file $_downloadPath');
   var bytes = await File(_downloadPath).readAsBytes();
   var decoded = gzip.decode(bytes);
   var writeStream = File(_finalPath).openWrite();
-  await writeStream.add(decoded);
+  writeStream.add(decoded);
   await writeStream.close();
 }
 
-void _download() async {
+Future<void> _download() async {
   var file = File(_downloadPath);
   if (await file.exists()) {
     print('GZ file exists');
@@ -50,6 +50,6 @@ void _download() async {
   await streamConsumer.close();
 }
 
-void main() {
-  downloadFromGithub();
+Future<void> main() async {
+  await downloadFromGithub();
 }

--- a/bin/github_download.dart
+++ b/bin/github_download.dart
@@ -1,19 +1,21 @@
 
 import 'dart:io';
 
+const pactVersion = '0.1.1';
+
 String _getDownloadLink() {
   if (Platform.isLinux) {
-    return 'https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v0.0.17/libpact_mock_server_ffi-linux-x86_64.so.gz';
+    return 'https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v$pactVersion/libpact_mock_server_ffi-linux-x86_64.so.gz';
   } else if (Platform.isMacOS) {
-    return 'https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v0.0.17/libpact_mock_server_ffi-osx-x86_64.dylib.gz';
+    return 'https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v$pactVersion/libpact_mock_server_ffi-osx-x86_64.dylib.gz';
   } else if (Platform.isWindows) {
-    return 'https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v0.0.17/libpact_mock_server_ffi-windows-x86_64.dll.gz';
+    return 'https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v$pactVersion/libpact_mock_server_ffi-windows-x86_64.dll.gz';
   }
   throw Exception('Unsupported platform: ${Platform.operatingSystem}');
 }
 
-final _finalPath = Directory.systemTemp.path + '/libpact_mock_server_ffi-v0.0.17';
-final _downloadPath = Directory.systemTemp.path + '/libpact_mock_server_ffi-v0.0.17.gz';
+final _finalPath = '${Directory.systemTemp.path}/libpact_mock_server_ffi-v$pactVersion';
+final _downloadPath = '${Directory.systemTemp.path}/libpact_mock_server_ffi-v$pactVersion.gz';
 
 Future<String> downloadFromGithub() async {
   if (await File(_finalPath).exists()) {
@@ -27,25 +29,26 @@ Future<String> downloadFromGithub() async {
 
 Future<void> _unzip() async {
   print('Decompressing file $_downloadPath');
-  var bytes = await File(_downloadPath).readAsBytes();
-  var decoded = gzip.decode(bytes);
-  var writeStream = File(_finalPath).openWrite();
+  final bytes = await File(_downloadPath).readAsBytes();
+  final decoded = gzip.decode(bytes);
+  print('Writing file $_finalPath');
+  final writeStream = File(_finalPath).openWrite();
   writeStream.add(decoded);
   await writeStream.close();
 }
 
 Future<void> _download() async {
-  var file = File(_downloadPath);
+  final file = File(_downloadPath);
   if (await file.exists()) {
     print('GZ file exists');
     return;
   }
 
-  var link = _getDownloadLink();
+  final link = _getDownloadLink();
   print('Downloading gz file: $link');
-  var request = await HttpClient().getUrl(Uri.parse(link));
-  var response = await request.close();
-  var streamConsumer = file.openWrite();
+  final request = await HttpClient().getUrl(Uri.parse(link));
+  final response = await request.close();
+  final streamConsumer = file.openWrite();
   await response.pipe(streamConsumer);
   await streamConsumer.close();
 }

--- a/build.yaml
+++ b/build.yaml
@@ -13,4 +13,3 @@ targets:
           generic_argument_factories: false
           ignore_unannotated: false
           include_if_null: false
-          nullable: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,0 @@
-FROM pactfoundation/pact-broker:2.79.0.1
-
-#https://hub.docker.com/r/pactfoundation/pact-broker
-ENV PACT_BROKER_PORT=9292
-# change when final db is available
-ENV PACT_BROKER_DATABASE_ADAPTER="sqlite"
-ENV PACT_BROKER_LOG_LEVEL="INFO"
-ENV PACT_BROKER_SQL_LOG_LEVEL="DEBUG"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,8 +1,13 @@
 version: "3"
 services:
   local-pact-broker:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: pactfoundation/pact-broker:2.79.0.1
+    environment:
+      #https://hub.docker.com/r/pactfoundation/pact-broker
+      - PACT_BROKER_PORT=9292
+      # change when final db is available
+      - PACT_BROKER_DATABASE_ADAPTER=sqlite
+      - PACT_BROKER_LOG_LEVEL=INFO
+      - PACT_BROKER_SQL_LOG_LEVEL=DEBUG
     ports:
-      - 9292:9292
+      - "9292:9292"

--- a/integration_test/pact_host_client_test.dart
+++ b/integration_test/pact_host_client_test.dart
@@ -3,8 +3,15 @@ import 'package:dart_pact_consumer/src/pact_host_client.dart';
 import 'package:test/test.dart';
 
 void main() {
+  const pactHostEnv = 'PACT_HOST';
+  assert(
+    const bool.hasEnvironment(pactHostEnv),
+    'Please define the PACT_HOST env variable',
+  );
+  const hostAddress = String.fromEnvironment(pactHostEnv);
+
   group('PactHost', () {
-    const host = 'http://192.168.96.1:9292';
+    const host = 'http://$hostAddress';
     final client = PactHost(host);
 
     test('should get contracts', () async {
@@ -15,6 +22,8 @@ void main() {
           'pet-shop-api-provider', '0.0.1', 'my-special-tag');
 
       await client.addLabel('pet-shop-api-provider', 'my-label');
+
+      client.close(force: true);
     });
   });
 }

--- a/integration_test/pact_host_client_test.dart
+++ b/integration_test/pact_host_client_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('PactHost', () {
-    const host = 'http://localhost:9292';
+    const host = 'http://192.168.96.1:9292';
     final client = PactHost(host);
 
     test('should get contracts', () async {

--- a/integration_test/pact_publish_test.dart
+++ b/integration_test/pact_publish_test.dart
@@ -15,9 +15,7 @@ void main() async {
     final repo = PactRepository();
 
     PactBuilder petShopApiBuilder() {
-      return PactBuilder()
-        ..consumer = 'dart-consumer'
-        ..provider = 'pet-shop-api-provider';
+      return PactBuilder('dart-consumer', 'pet-shop-api-provider');
     }
 
     test('should get pet list', () async {

--- a/integration_test/pact_publish_test.dart
+++ b/integration_test/pact_publish_test.dart
@@ -7,7 +7,14 @@ import 'package:dart_pact_consumer/src/pact_host_client.dart';
 import 'package:test/test.dart';
 
 void main() async {
-  const brokerUrl = 'http://192.168.96.1:9292';
+  const pactHostEnv = 'PACT_HOST';
+  assert(
+    const bool.hasEnvironment(pactHostEnv),
+    'Please define the PACT_HOST env variable',
+  );
+  const hostAddress = String.fromEnvironment(pactHostEnv);
+
+  const brokerUrl = 'http://$hostAddress';
   final serverFactory = await MockServerFactory.create();
 
   group('ContractBuilder for pact broker', () {
@@ -74,6 +81,7 @@ void main() async {
       final closed = serverFactory.close();
       expect(closed, isTrue);
       await repo.publish(host, '0.0.1');
+      host.close(force: true);
     });
   });
 

--- a/integration_test/pact_publish_test.dart
+++ b/integration_test/pact_publish_test.dart
@@ -7,7 +7,7 @@ import 'package:dart_pact_consumer/src/pact_host_client.dart';
 import 'package:test/test.dart';
 
 void main() async {
-  const brokerUrl = 'http://localhost:9292';
+  const brokerUrl = 'http://192.168.96.1:9292';
   final serverFactory = await MockServerFactory.create();
 
   group('ContractBuilder for pact broker', () {

--- a/lib/src/contract_builder_api.dart
+++ b/lib/src/contract_builder_api.dart
@@ -37,7 +37,7 @@ class PactRepository {
   }
 
   /// Gets a pact file in JSON format
-  String getPactFile(String consumer, String provider) {
+  String? getPactFile(String consumer, String provider) {
     return _pacts[_key(consumer, provider)].let((value) {
       return jsonEncode(value);
     });
@@ -99,7 +99,7 @@ class RequestTester {
 
   RequestTester._(this._stateBuilder);
 
-  void test(MockServerFactory factory, RequestTestFunction testFunction) async {
+  Future<void> test(MockServerFactory factory, RequestTestFunction testFunction) async {
     final pactBuilder = PactBuilder()..stateBuilders.add(_stateBuilder);
     final pact = PactRepository._createHeader(pactBuilder);
     PactRepository._mergeInteractions(pactBuilder, pact);
@@ -132,8 +132,8 @@ class RequestTester {
 /// . Generators
 /// . Encoders
 class PactBuilder {
-  String consumer;
-  String provider;
+  late String consumer;
+  late String provider;
   final List<StateBuilder> _states = [];
 
   PactBuilder();
@@ -158,7 +158,7 @@ class PactBuilder {
 enum Method { GET, POST, DELETE, PUT }
 
 class StateBuilder {
-  String state;
+  late String state;
   bool _tested = false;
 
   final List<RequestBuilder> requests = [];
@@ -197,11 +197,11 @@ class RequestBuilder {
 
   String description = '';
   Method method = Method.GET;
-  ResponseBuilder _response;
+  late ResponseBuilder _response;
 
   Map<String, String> query = {};
 
-  ResponseBuilder get response => _response;
+  ResponseBuilder get response => _response ;
   Body body = Body.isNullOrAbsent();
 
   Map<String, String> headers = {};

--- a/lib/src/contract_builder_api.dart
+++ b/lib/src/contract_builder_api.dart
@@ -197,7 +197,7 @@ class RequestBuilder {
 
   Map<String, String> query = {};
 
-  ResponseBuilder get response => _response ;
+  ResponseBuilder get response => _response;
   Body body = Body.isNullOrAbsent();
 
   Map<String, String> headers = {};

--- a/lib/src/contract_builder_api.dart
+++ b/lib/src/contract_builder_api.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:dart_pact_consumer/dart_pact_consumer.dart';
 import 'package:dart_pact_consumer/src/ffi/rust_mock_server.dart';
 import 'package:dart_pact_consumer/src/functional.dart';
 import 'package:dart_pact_consumer/src/json_serialize.dart';
@@ -247,12 +246,12 @@ class Body extends Union3<Json, String, Unit> implements CustomJson {
   /// Body is explicitly null or is absent.
   ///
   /// [Doc](https://github.com/pact-foundation/pact-specification/tree/version-3#body-is-present-but-is-null)
-  Body.isNullOrAbsent() : super.t3(Unit());
+  Body.isNullOrAbsent() : super.t3(unit);
 
   @override
   dynamic toJson() {
-    var result = fold<Object>(
-      (js) => js.toJson(),
+    final result = fold<Object>(
+      (js) => js.toJson() as Object,
       (str) => str,
       (unit) => unit
     );

--- a/lib/src/ffi/README.md
+++ b/lib/src/ffi/README.md
@@ -2,7 +2,7 @@
 
 - allocate and free are manual. not good
 - need native libraries for os/arch
-- RUST ffi https://docs.rs/pact_mock_server_ffi/0.0.17/pact_mock_server_ffi
+- RUST ffi https://docs.rs/pact_mock_server_ffi/0.1.1/pact_mock_server_ffi
 - foreign code runs on an Isolate base. may be useful to clean resources
 - PACT_MOCK_LOG_LEVEL variable name
 - server ports are used to differentiate interactions on pacts. 
@@ -17,6 +17,3 @@
 ## Conclusions
 ### ffi only support custom structs as of 2.12
 Can't build pact file with library.
-
-### ffi breaks as of 2.12 with current bindings
-2.12 breaks compatibility anyways with null safe semantics

--- a/lib/src/ffi/rust_library_bindings.dart
+++ b/lib/src/ffi/rust_library_bindings.dart
@@ -50,7 +50,7 @@ extension _Utf8PointerExt on Pointer<Utf8> {
 /// will tell the log level. Defaults to **PACT_MOCK_LOG_LEVEL**
 /// Valid values for the log level are: TRACE; DEBUG; INFO; WARN; ERROR
 ///
-/// [Docs](https://docs.rs/pact_mock_server_ffi/0.0.17/pact_mock_server_ffi/fn.init.html)
+/// [Docs](https://docs.rs/pact_mock_server_ffi/0.1.1/pact_mock_server_ffi/fn.init.html)
 DynamicLibrary open(String libPath,
     {String envLogVariable = 'PACT_MOCK_LOG_LEVEL'}) {
   final lib = DynamicLibrary.open(libPath);
@@ -81,7 +81,7 @@ typedef _createMockServerDart = int Function(
 
 /// Creates a mock server for matching purposes.
 ///
-/// [Docs](https://docs.rs/pact_mock_server_ffi/0.0.17/pact_mock_server_ffi/fn.create_mock_server.html)
+/// [Docs](https://docs.rs/pact_mock_server_ffi/0.1.1/pact_mock_server_ffi/fn.create_mock_server.html)
 int createMockServer(DynamicLibrary lib, String jsonPact,
     {String host = '127.0.0.1', int port = 0, bool useTls = false}) {
   assert(port >= 0, 'Invalid port');
@@ -118,7 +118,7 @@ typedef _mockServerMatchedDart = int /*bool*/ Function(int mock_server_port);
 
 /// Returns a boolean indicating if the server on [port] as matched all requests.
 ///
-/// [Docs](https://docs.rs/pact_mock_server_ffi/0.0.17/pact_mock_server_ffi/fn.mock_server_matched.html)
+/// [Docs](https://docs.rs/pact_mock_server_ffi/0.1.1/pact_mock_server_ffi/fn.mock_server_matched.html)
 bool hasServerMatched(DynamicLibrary lib, int port) {
   final mockServerMatchedFunc =
       lib.lookupFunction<_mockServerMatchedNative, _mockServerMatchedDart>(
@@ -132,7 +132,7 @@ typedef _mockServerMismatchDart = Pointer<Utf8> Function(int mock_server_port);
 
 /// Returns a Json representation of all the mismatches that the server contains.
 ///
-/// [Docs](https://docs.rs/pact_mock_server_ffi/0.0.17/pact_mock_server_ffi/fn.mock_server_mismatches.html)
+/// [Docs](https://docs.rs/pact_mock_server_ffi/0.1.1/pact_mock_server_ffi/fn.mock_server_mismatches.html)
 String getJsonMismatch(DynamicLibrary lib, int port) {
   final mockServerMismatchFunc =
       lib.lookupFunction<_mockServerMismatchNative, _mockServerMismatchDart>(
@@ -151,7 +151,7 @@ typedef _cleanupMockServerDart = int /*bool*/ Function(int mock_server_port);
 /// Cleanups all resources for a previously created server. Returns true on
 /// successful cleanup and false if something went wrong or the server doesn't exist.
 ///
-/// [Docs](https://docs.rs/pact_mock_server_ffi/0.0.17/pact_mock_server_ffi/fn.cleanup_mock_server.html)
+/// [Docs](https://docs.rs/pact_mock_server_ffi/0.1.1/pact_mock_server_ffi/fn.cleanup_mock_server.html)
 bool cleanup(DynamicLibrary lib, int port) {
   final cleanupMockServerFunc =
       lib.lookupFunction<_cleanupMockServerNative, _cleanupMockServerDart>(

--- a/lib/src/ffi/rust_library_bindings.dart
+++ b/lib/src/ffi/rust_library_bindings.dart
@@ -36,14 +36,12 @@ class _BooleanBridge {
 
 extension _StringExt on String {
   Pointer<Utf8> toNative() {
-    return Utf8.toUtf8(this);
+    return this.toNativeUtf8();
   }
 }
 
 extension _Utf8PointerExt on Pointer<Utf8> {
-  String toDartString() => ref.toString();
-
-  bool isNull() => this == null || this == nullptr;
+  bool isNull() => this == nullptr;
 }
 
 /// Opens the shared library given a local path.

--- a/lib/src/ffi/rust_library_bindings.dart
+++ b/lib/src/ffi/rust_library_bindings.dart
@@ -86,7 +86,6 @@ typedef _createMockServerDart = int Function(
 /// [Docs](https://docs.rs/pact_mock_server_ffi/0.0.17/pact_mock_server_ffi/fn.create_mock_server.html)
 int createMockServer(DynamicLibrary lib, String jsonPact,
     {String host = '127.0.0.1', int port = 0, bool useTls = false}) {
-  port ??= 0;
   assert(port >= 0, 'Invalid port');
   final createMockServerFunc =
       lib.lookupFunction<_createMockServerNative, _createMockServerDart>(
@@ -162,7 +161,7 @@ bool cleanup(DynamicLibrary lib, int port) {
   return _booleanBridge.fromNative(cleanupMockServerFunc(port));
 }
 
-void writePactFile(DynamicLibrary lib, int port, {String directory}) {
+void writePactFile(DynamicLibrary lib, int port, {String? directory}) {
   final dirNative = directory == null ? nullptr : directory.toNative();
   var func = lib.lookupFunction<
       Int32 Function(Int32 port, Pointer<Utf8> directory),

--- a/lib/src/ffi/rust_mock_server.dart
+++ b/lib/src/ffi/rust_mock_server.dart
@@ -15,6 +15,7 @@ final _default_lib_path =
 /// bindings to create a mock server to execute the matching process.
 class MockServerFactory {
   final DynamicLibrary _ffiLib;
+  static const JsonCodec _codec = JsonCodec();
 
   final Map<int, MockServer> _servers = {};
 
@@ -32,7 +33,7 @@ class MockServerFactory {
       ..consumer = (Consumer()..name = 'consumer-for-mock-server')
       ..provider = (Provider()..name = 'provider-for-mock-server')
       ..interactions = [interaction];
-    final contractAsJsonString = json.encode(pact);
+    final contractAsJsonString = _codec.encode(pact);
 
     MockServer createServer() {
       const host = '127.0.0.1';
@@ -72,7 +73,7 @@ class MockServerFactory {
     var file = File(libPathNn);
     if (!await file.exists()) {
       throw PactException('Library $libPathNn not found.'
-          'Try to run dart "pub run dart_pact_consumer:github_download" to get it from Github');
+          'Try to run dart "dart run dart_pact_consumer:github_download" to get it from Github');
     }
 
     var lib = bindings.open(libPathNn);

--- a/lib/src/ffi/rust_mock_server.dart
+++ b/lib/src/ffi/rust_mock_server.dart
@@ -27,7 +27,7 @@ class MockServerFactory {
   /// on the external library is not possible.
   ///
   /// If [port] is null, then is assigned by the operating system
-  MockServer createMockServer(Interaction interaction, {int port}) {
+  MockServer createMockServer(Interaction interaction, {int? port}) {
     final pact = Pact()
       ..consumer = (Consumer()..name = 'consumer-for-mock-server')
       ..provider = (Provider()..name = 'provider-for-mock-server')
@@ -37,7 +37,7 @@ class MockServerFactory {
     MockServer createServer() {
       const host = '127.0.0.1';
       var serverPort = bindings.createMockServer(_ffiLib, contractAsJsonString,
-          host: host, port: port);
+          host: host, port: port ?? 0);
       return MockServer._(host, serverPort, _ffiLib, interaction);
     }
 
@@ -67,15 +67,15 @@ class MockServerFactory {
   ///
   /// [libPath] can be used to provide a different path for the rust core
   /// library. **Using a different library version has unpredictable results**.
-  static Future<MockServerFactory> create({String libPath}) async {
-    libPath ??= _default_lib_path;
-    var file = File(libPath);
+  static Future<MockServerFactory> create({String? libPath}) async {
+    final libPathNn = libPath ?? _default_lib_path;
+    var file = File(libPathNn);
     if (!await file.exists()) {
-      throw PactException('Library $libPath not found.'
+      throw PactException('Library $libPathNn not found.'
           'Try to run dart "pub run dart_pact_consumer:github_download" to get it from Github');
     }
 
-    var lib = bindings.open(libPath);
+    var lib = bindings.open(libPathNn);
     return MockServerFactory._(lib);
   }
 
@@ -127,13 +127,13 @@ extension MockServerExt on MockServer {
   Future<HttpClientResponse> invoke(
     String path, {
     String method = 'GET',
-    Object body,
+    Object? body,
     Map<String, String> headers = const {'accept': 'application/json'},
     int status = 200,
   }) async {
     final client = HttpClient();
     final uri = Uri.parse('$address$path');
-    var req = await client.openUrl(method, uri);
+    final req = await client.openUrl(method, uri);
     headers.forEach((key, value) {
       req.headers.add(key, value);
     });

--- a/lib/src/ffi/rust_mock_server.dart
+++ b/lib/src/ffi/rust_mock_server.dart
@@ -9,9 +9,9 @@ import '../functional.dart';
 import 'rust_library_bindings.dart' as bindings;
 
 final _default_lib_path =
-    Directory.systemTemp.path + '/libpact_mock_server_ffi-v0.0.17';
+    '${Directory.systemTemp.path}/libpact_mock_server_ffi-v0.1.1';
 
-/// Factory that uses the [rust ffi v0.0.17](https://docs.rs/pact_mock_server_ffi/0.0.17)
+/// Factory that uses the [rust ffi v0.1.1](https://docs.rs/pact_mock_server_ffi/0.1.1)
 /// bindings to create a mock server to execute the matching process.
 class MockServerFactory {
   final DynamicLibrary _ffiLib;

--- a/lib/src/functional.dart
+++ b/lib/src/functional.dart
@@ -3,8 +3,8 @@ import 'package:dart_pact_consumer/src/json_serialize.dart';
 typedef Mapper<T, R> = R Function(T input);
 
 class Union2<T1, T2> {
-  final T1 _t1;
-  final T2 _t2;
+  final T1? _t1;
+  final T2? _t2;
 
   Union2._(this._t1, this._t2) : assert(_t1 != null || _t2 != null);
 
@@ -13,14 +13,14 @@ class Union2<T1, T2> {
   Union2.t2(T2 t2) : this._(null, t2);
 
   R fold<R>(Mapper<T1, R> t1Mapper, Mapper<T2, R> t2Mapper) {
-    return _fold(t1Mapper, _t1) ?? _fold(t2Mapper, _t2);
+    return _fold(t1Mapper, _t1) ?? _fold(t2Mapper, _t2)!;
   }
 }
 
 class Union3<T1, T2, T3> {
-  final T1 _t1;
-  final T2 _t2;
-  final T3 _t3;
+  final T1? _t1;
+  final T2? _t2;
+  final T3? _t3;
 
   Union3._(this._t1, this._t2, this._t3)
       : assert(_t1 != null || _t2 != null || _t3 != null);
@@ -33,12 +33,14 @@ class Union3<T1, T2, T3> {
 
   R fold<R>(
       Mapper<T1, R> t1Mapper, Mapper<T2, R> t2Mapper, Mapper<T3, R> t3Mapper) {
-    return _fold(t1Mapper, _t1) ?? _fold(t2Mapper, _t2) ?? _fold(t3Mapper, _t3);
+    return _fold(t1Mapper, _t1) ??
+        _fold(t2Mapper, _t2) ??
+        _fold(t3Mapper, _t3)!;
   }
 }
 
-R _fold<R, W>(Mapper<W, R> mapper, [Object input]) {
-  if (input != null && input is W) {
+R? _fold<R, W>(Mapper<W, R> mapper, [Object? input]) {
+  if (input is W) {
     return mapper(input);
   }
   return null;
@@ -59,45 +61,51 @@ class Unit implements CustomJson {
   dynamic toJson() => null;
 }
 
-/// Ensures lazy initialization of non nullable values
-class Lazy<T> {
-  T _value;
-  T Function() _producer;
+/// Ensures a value either by provision or by lazy initialization
+class Default<T> {
+  T? _value;
+  T Function()? _producer;
 
-  Lazy(this._value, this._producer) : assert(_producer != null);
+  Default._(this._value, this._producer)
+      : assert(_producer != null || _value != null);
 
-  factory Lazy.fromProducer(T Function() producer) {
-    return Lazy(null, producer);
+  factory Default.fromProducer(T Function() producer) {
+    return Default._(null, producer);
+  }
+
+  factory Default.fromNullable(T? value, T Function() producer) {
+    return Default._(value, producer);
   }
 
   T get value {
-    _value ??= _producer();
+    _value ??= _producer?.call();
     assert(_value != null);
     _producer = null;
-    return _value;
+    return _value!;
   }
 }
 
+/// Replace with nullable
+@deprecated
 class Optional<T> extends Union2<T, Unit> {
-  Optional.value(T value)
-      : assert(value != null),
-        super.t1(value);
+  Optional.value(T value) : super.t1(value);
 
   Optional.empty() : super.t2(unit);
 
-  factory Optional.nullable(T value) {
+  factory Optional.nullable(T? value) {
     return value?.let((nonNull) => Optional.value(nonNull)) ?? Optional.empty();
   }
 }
 
-extension ScopeFunctions<T> on T {
+extension ScopeFunctions<T> on T? {
   /// Preforms an operation on a possible null input.
   ///
   /// The operation function is only executed on non null cases.
-  R let<R>(R Function(T value) func) {
-    if (this == null) {
+  R? let<R>(R Function(T value) func) {
+    final tmp = this;
+    if (tmp == null) {
       return null;
     }
-    return func(this);
+    return func(tmp);
   }
 }

--- a/lib/src/functional.dart
+++ b/lib/src/functional.dart
@@ -48,6 +48,8 @@ R? _fold<R, W>(Mapper<W, R> mapper, [Object? input]) {
   return null;
 }
 
+const unit = Unit._();
+
 /// Unit is a concept where a single instance exists.
 ///
 /// In most cases it represents the absence of a value, like [Void].
@@ -55,7 +57,7 @@ R? _fold<R, W>(Mapper<W, R> mapper, [Object? input]) {
 /// Work with unions to provide a difference between actual null and something
 /// that should be interpreted as null.
 class Unit implements CustomJson {
-  const Unit();
+  const Unit._();
 
   dynamic toJson() => null;
 }
@@ -81,18 +83,6 @@ class Default<T> {
     assert(_value != null);
     _producer = null;
     return _value!;
-  }
-}
-
-/// Replace with nullable
-@deprecated
-class Optional<T> extends Union2<T, Unit> {
-  Optional.value(T value) : super.t1(value);
-
-  Optional.empty() : super.t2(Unit());
-
-  factory Optional.nullable(T? value) {
-    return value?.let((nonNull) => Optional.value(nonNull)) ?? Optional.empty();
   }
 }
 

--- a/lib/src/functional.dart
+++ b/lib/src/functional.dart
@@ -12,7 +12,8 @@ class Union2<T1, T2> {
 
   Union2.t2(T2 t2) : this._(null, t2);
 
-  R fold<R>(Mapper<T1, R> t1Mapper, Mapper<T2, R> t2Mapper) {
+  /// Folds all values into a non nullable one
+  R fold<R extends Object>(Mapper<T1, R> t1Mapper, Mapper<T2, R> t2Mapper) {
     return _fold(t1Mapper, _t1) ?? _fold(t2Mapper, _t2)!;
   }
 }
@@ -31,7 +32,8 @@ class Union3<T1, T2, T3> {
 
   Union3.t3(T3 t3) : this._(null, null, t3);
 
-  R fold<R>(
+  /// Folds all values into a non nullable one
+  R fold<R extends Object>(
       Mapper<T1, R> t1Mapper, Mapper<T2, R> t2Mapper, Mapper<T3, R> t3Mapper) {
     return _fold(t1Mapper, _t1) ??
         _fold(t2Mapper, _t2) ??
@@ -46,8 +48,6 @@ R? _fold<R, W>(Mapper<W, R> mapper, [Object? input]) {
   return null;
 }
 
-final unit = Unit._();
-
 /// Unit is a concept where a single instance exists.
 ///
 /// In most cases it represents the absence of a value, like [Void].
@@ -55,9 +55,8 @@ final unit = Unit._();
 /// Work with unions to provide a difference between actual null and something
 /// that should be interpreted as null.
 class Unit implements CustomJson {
-  Unit._();
+  const Unit();
 
-  @override
   dynamic toJson() => null;
 }
 
@@ -90,7 +89,7 @@ class Default<T> {
 class Optional<T> extends Union2<T, Unit> {
   Optional.value(T value) : super.t1(value);
 
-  Optional.empty() : super.t2(unit);
+  Optional.empty() : super.t2(Unit());
 
   factory Optional.nullable(T? value) {
     return value?.let((nonNull) => Optional.value(nonNull)) ?? Optional.empty();

--- a/lib/src/json_serialize.dart
+++ b/lib/src/json_serialize.dart
@@ -8,5 +8,14 @@
 ///
 /// Use this only on classes that shouldn't be annotated with [JsonSerializable]
 abstract class CustomJson {
+  /// To be called for a custom json serialization.
+  /// This is not a chainable call. If the result is writeable by the
+  /// stringifier, it will result in an exception.
   dynamic toJson();
+}
+
+/// Same as [CustomJson] but reified.
+/// Use with [JsonSerializable] annotated classes
+abstract class ReifiedJson {
+  Map<String, dynamic> toJson();
 }

--- a/lib/src/pact_contract_dto.dart
+++ b/lib/src/pact_contract_dto.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 
 import 'contract_builder_api.dart';
+import 'json_serialize.dart';
 
 part 'pact_contract_dto.g.dart';
 
@@ -8,9 +9,9 @@ part 'pact_contract_dto.g.dart';
 // https://github.com/pact-foundation/pact-specification/tree/version-3
 
 @JsonSerializable()
-class Pact {
-  Provider provider;
-  Consumer consumer;
+class Pact implements ReifiedJson {
+  late Provider provider;
+  late Consumer consumer;
   List<Interaction> interactions = [];
   Metadata metadata = Metadata();
 
@@ -23,7 +24,7 @@ class Pact {
 }
 
 @JsonSerializable()
-class Metadata {
+class Metadata implements ReifiedJson {
   Metadata();
 
   Map<String, String> pactSpecification = {'version': '3.0.0'};
@@ -38,10 +39,10 @@ class Metadata {
 }
 
 @JsonSerializable()
-class Interaction {
-  String description;
-  Request request;
-  Response response;
+class Interaction implements ReifiedJson {
+  String? description;
+  late Request request;
+  late Response response;
   List<ProviderState> providerStates = [];
 
   Interaction();
@@ -53,8 +54,8 @@ class Interaction {
 }
 
 @JsonSerializable()
-class ProviderState {
-  String name;
+class ProviderState implements ReifiedJson {
+  late String name;
   Map<String, dynamic> params = {};
 
   ProviderState();
@@ -66,15 +67,15 @@ class ProviderState {
 }
 
 @JsonSerializable()
-class Response {
-  int status;
+class Response implements ReifiedJson {
+  late int status;
 
   Response();
 
   Map<String, String> headers = {};
 
   @JsonKey(fromJson: Body.fromJsonToBody)
-  Body body;
+  late Body body;
 
   factory Response.fromJson(Map<String, dynamic> json) =>
       _$ResponseFromJson(json);
@@ -83,16 +84,16 @@ class Response {
 }
 
 @JsonSerializable()
-class Request {
+class Request implements ReifiedJson {
   Request();
 
-  String method;
-  String path;
+  late String method;
+  late String path;
   Map<String, String> query = {};
   Map<String, String> headers = {};
 
   @JsonKey(fromJson: Body.fromJsonToBody)
-  Body body;
+  late Body body;
 
   factory Request.fromJson(Map<String, dynamic> json) =>
       _$RequestFromJson(json);
@@ -101,8 +102,8 @@ class Request {
 }
 
 @JsonSerializable()
-class Provider {
-  String name;
+class Provider implements ReifiedJson {
+  late String name;
 
   Provider();
 
@@ -113,8 +114,8 @@ class Provider {
 }
 
 @JsonSerializable()
-class Consumer {
-  String name;
+class Consumer implements ReifiedJson {
+  late String name;
 
   Consumer();
 

--- a/lib/src/pact_contract_dto.g.dart
+++ b/lib/src/pact_contract_dto.g.dart
@@ -6,200 +6,94 @@ part of 'pact_contract_dto.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-Pact _$PactFromJson(Map<String, dynamic> json) {
-  return Pact()
-    ..provider = json['provider'] == null
-        ? null
-        : Provider.fromJson(json['provider'] as Map<String, dynamic>)
-    ..consumer = json['consumer'] == null
-        ? null
-        : Consumer.fromJson(json['consumer'] as Map<String, dynamic>)
-    ..interactions = (json['interactions'] as List)
-        ?.map((e) =>
-            e == null ? null : Interaction.fromJson(e as Map<String, dynamic>))
-        ?.toList()
-    ..metadata = json['metadata'] == null
-        ? null
-        : Metadata.fromJson(json['metadata'] as Map<String, dynamic>);
-}
+Pact _$PactFromJson(Map<String, dynamic> json) => Pact()
+  ..provider = Provider.fromJson(json['provider'] as Map<String, dynamic>)
+  ..consumer = Consumer.fromJson(json['consumer'] as Map<String, dynamic>)
+  ..interactions = (json['interactions'] as List<dynamic>)
+      .map((e) => Interaction.fromJson(e as Map<String, dynamic>))
+      .toList()
+  ..metadata = Metadata.fromJson(json['metadata'] as Map<String, dynamic>);
 
-Map<String, dynamic> _$PactToJson(Pact instance) {
-  final val = <String, dynamic>{};
+Map<String, dynamic> _$PactToJson(Pact instance) => <String, dynamic>{
+      'provider': instance.provider,
+      'consumer': instance.consumer,
+      'interactions': instance.interactions,
+      'metadata': instance.metadata,
+    };
 
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
+Metadata _$MetadataFromJson(Map<String, dynamic> json) => Metadata()
+  ..pactSpecification =
+      Map<String, String>.from(json['pactSpecification'] as Map)
+  ..pactDart = Map<String, String>.from(json['pact-dart'] as Map);
 
-  writeNotNull('provider', instance.provider);
-  writeNotNull('consumer', instance.consumer);
-  writeNotNull('interactions', instance.interactions);
-  writeNotNull('metadata', instance.metadata);
-  return val;
-}
+Map<String, dynamic> _$MetadataToJson(Metadata instance) => <String, dynamic>{
+      'pactSpecification': instance.pactSpecification,
+      'pact-dart': instance.pactDart,
+    };
 
-Metadata _$MetadataFromJson(Map<String, dynamic> json) {
-  return Metadata()
-    ..pactSpecification =
-        (json['pactSpecification'] as Map<String, dynamic>)?.map(
-      (k, e) => MapEntry(k, e as String),
-    )
-    ..pactDart = (json['pact-dart'] as Map<String, dynamic>)?.map(
-      (k, e) => MapEntry(k, e as String),
-    );
-}
+Interaction _$InteractionFromJson(Map<String, dynamic> json) => Interaction()
+  ..description = json['description'] as String
+  ..request = Request.fromJson(json['request'] as Map<String, dynamic>)
+  ..response = Response.fromJson(json['response'] as Map<String, dynamic>)
+  ..providerStates = (json['providerStates'] as List<dynamic>)
+      .map((e) => ProviderState.fromJson(e as Map<String, dynamic>))
+      .toList();
 
-Map<String, dynamic> _$MetadataToJson(Metadata instance) {
-  final val = <String, dynamic>{};
+Map<String, dynamic> _$InteractionToJson(Interaction instance) =>
+    <String, dynamic>{
+      'description': instance.description,
+      'request': instance.request,
+      'response': instance.response,
+      'providerStates': instance.providerStates,
+    };
 
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
+ProviderState _$ProviderStateFromJson(Map<String, dynamic> json) =>
+    ProviderState()
+      ..name = json['name'] as String
+      ..params = json['params'] as Map<String, dynamic>;
 
-  writeNotNull('pactSpecification', instance.pactSpecification);
-  writeNotNull('pact-dart', instance.pactDart);
-  return val;
-}
+Map<String, dynamic> _$ProviderStateToJson(ProviderState instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'params': instance.params,
+    };
 
-Interaction _$InteractionFromJson(Map<String, dynamic> json) {
-  return Interaction()
-    ..description = json['description'] as String
-    ..request = json['request'] == null
-        ? null
-        : Request.fromJson(json['request'] as Map<String, dynamic>)
-    ..response = json['response'] == null
-        ? null
-        : Response.fromJson(json['response'] as Map<String, dynamic>)
-    ..providerStates = (json['providerStates'] as List)
-        ?.map((e) => e == null
-            ? null
-            : ProviderState.fromJson(e as Map<String, dynamic>))
-        ?.toList();
-}
+Response _$ResponseFromJson(Map<String, dynamic> json) => Response()
+  ..status = json['status'] as int
+  ..headers = Map<String, String>.from(json['headers'] as Map)
+  ..body = Body.fromJsonToBody(json['body']);
 
-Map<String, dynamic> _$InteractionToJson(Interaction instance) {
-  final val = <String, dynamic>{};
+Map<String, dynamic> _$ResponseToJson(Response instance) => <String, dynamic>{
+      'status': instance.status,
+      'headers': instance.headers,
+      'body': instance.body,
+    };
 
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
+Request _$RequestFromJson(Map<String, dynamic> json) => Request()
+  ..method = json['method'] as String
+  ..path = json['path'] as String
+  ..query = Map<String, String>.from(json['query'] as Map)
+  ..headers = Map<String, String>.from(json['headers'] as Map)
+  ..body = Body.fromJsonToBody(json['body']);
 
-  writeNotNull('description', instance.description);
-  writeNotNull('request', instance.request);
-  writeNotNull('response', instance.response);
-  writeNotNull('providerStates', instance.providerStates);
-  return val;
-}
+Map<String, dynamic> _$RequestToJson(Request instance) => <String, dynamic>{
+      'method': instance.method,
+      'path': instance.path,
+      'query': instance.query,
+      'headers': instance.headers,
+      'body': instance.body,
+    };
 
-ProviderState _$ProviderStateFromJson(Map<String, dynamic> json) {
-  return ProviderState()
-    ..name = json['name'] as String
-    ..params = json['params'] as Map<String, dynamic>;
-}
+Provider _$ProviderFromJson(Map<String, dynamic> json) =>
+    Provider()..name = json['name'] as String;
 
-Map<String, dynamic> _$ProviderStateToJson(ProviderState instance) {
-  final val = <String, dynamic>{};
+Map<String, dynamic> _$ProviderToJson(Provider instance) => <String, dynamic>{
+      'name': instance.name,
+    };
 
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
+Consumer _$ConsumerFromJson(Map<String, dynamic> json) =>
+    Consumer()..name = json['name'] as String;
 
-  writeNotNull('name', instance.name);
-  writeNotNull('params', instance.params);
-  return val;
-}
-
-Response _$ResponseFromJson(Map<String, dynamic> json) {
-  return Response()
-    ..status = json['status'] as int
-    ..headers = (json['headers'] as Map<String, dynamic>)?.map(
-      (k, e) => MapEntry(k, e as String),
-    )
-    ..body = Body.fromJsonToBody(json['body']);
-}
-
-Map<String, dynamic> _$ResponseToJson(Response instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('status', instance.status);
-  writeNotNull('headers', instance.headers);
-  writeNotNull('body', instance.body);
-  return val;
-}
-
-Request _$RequestFromJson(Map<String, dynamic> json) {
-  return Request()
-    ..method = json['method'] as String
-    ..path = json['path'] as String
-    ..query = (json['query'] as Map<String, dynamic>)?.map(
-      (k, e) => MapEntry(k, e as String),
-    )
-    ..headers = (json['headers'] as Map<String, dynamic>)?.map(
-      (k, e) => MapEntry(k, e as String),
-    )
-    ..body = Body.fromJsonToBody(json['body']);
-}
-
-Map<String, dynamic> _$RequestToJson(Request instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('method', instance.method);
-  writeNotNull('path', instance.path);
-  writeNotNull('query', instance.query);
-  writeNotNull('headers', instance.headers);
-  writeNotNull('body', instance.body);
-  return val;
-}
-
-Provider _$ProviderFromJson(Map<String, dynamic> json) {
-  return Provider()..name = json['name'] as String;
-}
-
-Map<String, dynamic> _$ProviderToJson(Provider instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('name', instance.name);
-  return val;
-}
-
-Consumer _$ConsumerFromJson(Map<String, dynamic> json) {
-  return Consumer()..name = json['name'] as String;
-}
-
-Map<String, dynamic> _$ConsumerToJson(Consumer instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('name', instance.name);
-  return val;
-}
+Map<String, dynamic> _$ConsumerToJson(Consumer instance) => <String, dynamic>{
+      'name': instance.name,
+    };

--- a/lib/src/pact_host_client.dart
+++ b/lib/src/pact_host_client.dart
@@ -81,6 +81,10 @@ class PactHost {
     }
     return '';
   }
+
+  void close({bool force = false}) {
+    _client.close(force: force);
+  }
 }
 
 class PactHostException {

--- a/lib/src/pact_host_client.dart
+++ b/lib/src/pact_host_client.dart
@@ -6,12 +6,12 @@ import 'package:dart_pact_consumer/src/pact_contract_dto.dart';
 
 class PactHost {
   final String _hostUri;
-  final Lazy<HttpClient> _lazyClient;
+  final Default<HttpClient> _lazyClient;
 
   HttpClient get _client => _lazyClient.value;
 
-  PactHost(this._hostUri, {HttpClient client})
-      : _lazyClient = Lazy(client, () => HttpClient());
+  PactHost(this._hostUri, {HttpClient? client})
+      : _lazyClient = Default.fromNullable(client, () => HttpClient());
 
   Future<void> publishContract(Pact contract, String version) async {
     final urlStr =
@@ -73,8 +73,8 @@ class PactHost {
       return '';
     }
     final contentType = response.headers.contentType;
-    if (contentType.mimeType == ContentType.json.mimeType ||
-        contentType.mimeType == ContentType.text.mimeType) {
+    if (contentType?.mimeType == ContentType.json.mimeType ||
+        contentType?.mimeType == ContentType.text.mimeType) {
       return response.fold<List<int>>([], (prev, elem) => prev..addAll(elem))
           // todo fixed encoding
           .then((value) => utf8.decode(value));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,13 +4,13 @@ version: 0.1.0
 # homepage: https://www.example.com
 repository: https://github.com/pak3nuh/dart_pact_consumer/tree/main
 environment:
-  sdk: '>=2.10.4 <2.12.0'
+  sdk: '>=2.12.0 < 3.0.0'
 
 dependencies:
   json_serializable: ">=3.2.0 <4.0.0"
   json_annotation: ^3.0.0
   path: ^1.7.0
-  ffi: ^0.1.3
+  ffi: ^1.0.0
 
 dev_dependencies:
   pedantic: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,6 @@
 name: dart_pact_consumer
 description: A consumer library to build and test pact contracts.
 version: 0.2.0
-# homepage: https://www.example.com
 repository: https://github.com/pak3nuh/dart_pact_consumer/tree/main
 environment:
   sdk: '>=2.12.0 < 3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,18 @@
 name: dart_pact_consumer
 description: A consumer library to build and test pact contracts.
-version: 0.1.0
+version: 0.2.0
 # homepage: https://www.example.com
 repository: https://github.com/pak3nuh/dart_pact_consumer/tree/main
 environment:
   sdk: '>=2.12.0 < 3.0.0'
 
 dependencies:
-  json_serializable: ">=3.2.0 <4.0.0"
-  json_annotation: ^3.0.0
-  path: ^1.7.0
-  ffi: ^1.0.0
+  json_serializable: ^5.0.2
+  json_annotation: ^4.1.0
+  path: ^1.8.3
+  ffi: ^1.2.1
 
 dev_dependencies:
-  pedantic: ^1.9.0
-  test: ^1.15.7
+  pedantic_mono: ^1.14.0
+  test: ^1.17.12
   build_runner:

--- a/test/ffi/mock_server_test.dart
+++ b/test/ffi/mock_server_test.dart
@@ -1,14 +1,11 @@
-import 'dart:io';
 
 import 'package:dart_pact_consumer/dart_pact_consumer.dart';
 import 'package:dart_pact_consumer/src/ffi/rust_mock_server.dart';
-import 'package:dart_pact_consumer/src/functional.dart';
 import 'package:dart_pact_consumer/src/pact_exceptions.dart';
 import 'package:test/test.dart';
 
 void main() async {
   final serverFactory = await MockServerFactory.create();
-  final repository = PactRepository();
 
   group('Mock server tests', () {
     tearDownAll(() {

--- a/test/ffi/mock_server_test.dart
+++ b/test/ffi/mock_server_test.dart
@@ -16,9 +16,7 @@ void main() async {
     });
 
     test('should fail with no interactions', () async {
-      final builder = PactBuilder()
-        ..consumer = 'consumer'
-        ..provider = 'provider';
+      final builder = PactBuilder('consumer', 'provider');
       final tester = builder.addState((state) {
         state.state = 'Given empty pet list';
         state.addRequest((request) {
@@ -40,9 +38,7 @@ void main() async {
     });
 
     test('should pass when interacted', () async {
-      final builder = PactBuilder()
-        ..consumer = 'consumer'
-        ..provider = 'provider';
+      final builder = PactBuilder('consumer', 'provider');
       final tester = builder.addState((state) {
         state.state = 'Given empty pet list';
         state.addRequest((request) {
@@ -61,9 +57,7 @@ void main() async {
     });
 
     test('should accept bodies as payload', () async {
-      final builder = PactBuilder()
-        ..consumer = 'consumer'
-        ..provider = 'provider';
+      final builder = PactBuilder('consumer', 'provider');
       final tester = builder.addState((state) {
         state.state = 'Given empty pet list';
         state.addRequest((request) {

--- a/test/functional_test.dart
+++ b/test/functional_test.dart
@@ -8,7 +8,7 @@ void main() {
 
   group('Scope functions', () {
     test('should not map null inputs', () {
-        final String s = null;
+        final String? s = null;
         final result = s.let((value) => throw Exception());
         expect(result, isNull);
     });
@@ -23,7 +23,7 @@ void main() {
   group('Lazy', (){
       test('should invoke producer only once', () {
           var flag = false;
-          var lazy = Lazy.fromProducer(() {
+          var lazy = Default.fromProducer(() {
               if (flag) {
                   throw 'problem';
               }

--- a/test/pact_repository_test.dart
+++ b/test/pact_repository_test.dart
@@ -25,9 +25,7 @@ void main() {
 }
 
 PactBuilder simpleBuilder() {
-  return PactBuilder()
-      ..consumer = 'consumer'
-      ..provider = 'provider'
+  return PactBuilder('consumer', 'provider')
       ..addState((stateBuilder) {
         stateBuilder
           ..state = 'my state'


### PR DESCRIPTION
The long awaited PR that enables null safety and stabilizes FFI.

This PR also bumps dependencies to the latest version that supports the SDK 2.12.

The bump isn't to a newer SDK to increase compatibility as none of the newer features are needed for now.

Closes #12 